### PR TITLE
terraform, aws: comment instance_refresh on asg

### DIFF
--- a/terraform/aws/aws-ec2-autoscaling-dual-subnet/README.md
+++ b/terraform/aws/aws-ec2-autoscaling-dual-subnet/README.md
@@ -19,6 +19,7 @@ This module creates the following:
 
 ## Considerations
 
+- The Auto Scaling Group does not define an `instance_refresh` policy as the ASG cannot do a rolling restart with externally manaaged network interfaces (ENIs) as required by this configuration. To update instances to the latest launch template, terminate instances in the ASG in the AWS Console or programmatically. This will release the ENI so the replacement instance can use it.
 - Any advertised routes and exit nodes must still be approved in the Tailscale Admin Console. The code can be updated to use [Auto Approvers for routes](https://tailscale.com/kb/1018/acls/#auto-approvers-for-routes-and-exit-nodes) if this is configured in your ACLs.
 
 ## To use

--- a/terraform/aws/aws-ec2-autoscaling/README.md
+++ b/terraform/aws/aws-ec2-autoscaling/README.md
@@ -9,6 +9,7 @@ This example creates the following:
 
 ## Considerations
 
+- The Auto Scaling Group does not define an `instance_refresh` policy as the ASG cannot do a rolling restart with externally manaaged network interfaces (ENIs) as required by this configuration. To update instances to the latest launch template, terminate instances in the ASG in the AWS Console or programmatically. This will release the ENI so the replacement instance can use it.
 - Any advertised routes and exit nodes must still be approved in the Tailscale Admin Console. The code can be updated to use [Auto Approvers for routes](https://tailscale.com/kb/1018/acls/#auto-approvers-for-routes-and-exit-nodes) if this is configured in your ACLs.
 
 ## To use

--- a/terraform/aws/internal-modules/aws-ec2-autoscaling/variables.tf
+++ b/terraform/aws/internal-modules/aws-ec2-autoscaling/variables.tf
@@ -20,7 +20,7 @@ variable "instance_key_name" {
 }
 variable "instance_profile_name" {
   type    = string
-  default = null
+  default = ""
 }
 variable "instance_metadata_options" {
   type = map(string)


### PR DESCRIPTION
Uncomment to allow ASG to replace the instance. It will take several minutes as the ASG will try to launch a replacement instance before ENIs have been released.