### PR TITLE
terraform/aws: aws-ec2-instance-dual-stack-ipv4-ipv6, add ipv6_address_count

### DIFF
--- a/terraform/aws/aws-ec2-instance-dual-stack-ipv4-ipv6/main.tf
+++ b/terraform/aws/aws-ec2-instance-dual-stack-ipv4-ipv6/main.tf
@@ -39,10 +39,11 @@ module "tailscale_aws_ec2" {
   instance_type = "t4g.micro"
   instance_tags = local.tags
 
-  subnet_id = module.vpc.public_subnets[0]
+  subnet_id = module.vpc.private_subnets[0]
   vpc_security_group_ids = [
     module.vpc.tailscale_security_group_id,
   ]
+  ipv6_address_count = 1
 
   # Variables for Tailscale resources
   tailscale_hostname = local.name

--- a/terraform/aws/internal-modules/aws-ec2-instance/main.tf
+++ b/terraform/aws/internal-modules/aws-ec2-instance/main.tf
@@ -42,6 +42,7 @@ resource "aws_instance" "tailscale_instance" {
 
   subnet_id              = var.subnet_id
   vpc_security_group_ids = var.vpc_security_group_ids
+  ipv6_address_count     = var.ipv6_address_count
   source_dest_check      = !module.tailscale_install_scripts.ip_forwarding_required
 
   iam_instance_profile = var.instance_profile_name

--- a/terraform/aws/internal-modules/aws-ec2-instance/variables.tf
+++ b/terraform/aws/internal-modules/aws-ec2-instance/variables.tf
@@ -4,6 +4,10 @@
 variable "subnet_id" {
   type = string
 }
+variable "ipv6_address_count" {
+  type    = number
+  default = null
+}
 variable "vpc_security_group_ids" {
   type = set(string)
 }


### PR DESCRIPTION
add an explicit ipv6 address to the instance in `aws-ec2-instance-dual-stack-ipv4-ipv6`