### PR TITLE
terraform: refactor module inputs

### DIFF
--- a/terraform/aws/aws-ec2-autoscaling-dual-subnet/main.tf
+++ b/terraform/aws/aws-ec2-autoscaling-dual-subnet/main.tf
@@ -69,21 +69,13 @@ module "tailscale_aws_ec2_autoscaling" {
   tailscale_auth_key = tailscale_tailnet_key.main.key
   tailscale_set_preferences = [
     "--auto-update",
+    "--ssh",
+    "--advertise-routes=${join(",", [module.vpc.vpc_cidr_block])}",
+    "--advertise-exit-node=true",
+    "--advertise-connector=true",
   ]
-  tailscale_ssh                 = true
-  tailscale_advertise_exit_node = true
-
-  tailscale_advertise_routes = [
-    module.vpc.vpc_cidr_block,
-  ]
-
-  tailscale_advertise_connector = true
-  # tailscale_advertise_aws_service_names = [
-  #   "GLOBALACCELERATOR",
-  # ]
 
   depends_on = [
     module.vpc.natgw_ids, # ensure NAT gateway is available before instance provisioning - primarily for private subnets
   ]
 }
-

--- a/terraform/aws/aws-ec2-autoscaling-dual-subnet/main.tf
+++ b/terraform/aws/aws-ec2-autoscaling-dual-subnet/main.tf
@@ -70,9 +70,9 @@ module "tailscale_aws_ec2_autoscaling" {
   tailscale_set_preferences = [
     "--auto-update",
     "--ssh",
+    "--advertise-connector",
+    "--advertise-exit-node",
     "--advertise-routes=${join(",", [module.vpc.vpc_cidr_block])}",
-    "--advertise-exit-node=true",
-    "--advertise-connector=true",
   ]
 
   depends_on = [

--- a/terraform/aws/aws-ec2-autoscaling-session-recorder/main.tf
+++ b/terraform/aws/aws-ec2-autoscaling-session-recorder/main.tf
@@ -158,8 +158,8 @@ module "tailscale_aws_ec2_autoscaling" {
   tailscale_auth_key = tailscale_tailnet_key.main.key
   tailscale_set_preferences = [
     "--auto-update",
+    "-ssh",
   ]
-  tailscale_ssh = true
 
   #
   # Set up Tailscale Session Recorder (tsrecorder)

--- a/terraform/aws/aws-ec2-autoscaling/main.tf
+++ b/terraform/aws/aws-ec2-autoscaling/main.tf
@@ -59,9 +59,9 @@ module "tailscale_aws_ec2_autoscaling" {
   tailscale_set_preferences = [
     "--auto-update",
     "--ssh",
+    "--advertise-connector",
+    "--advertise-exit-node",
     "--advertise-routes=${join(",", [module.vpc.vpc_cidr_block])}",
-    "--advertise-exit-node=true",
-    "--advertise-connector=true",
   ]
 
   depends_on = [

--- a/terraform/aws/aws-ec2-autoscaling/main.tf
+++ b/terraform/aws/aws-ec2-autoscaling/main.tf
@@ -58,18 +58,11 @@ module "tailscale_aws_ec2_autoscaling" {
   tailscale_hostname = local.name
   tailscale_set_preferences = [
     "--auto-update",
+    "--ssh",
+    "--advertise-routes=${join(",", [module.vpc.vpc_cidr_block])}",
+    "--advertise-exit-node=true",
+    "--advertise-connector=true",
   ]
-  tailscale_ssh                 = true
-  tailscale_advertise_exit_node = true
-
-  tailscale_advertise_routes = [
-    module.vpc.vpc_cidr_block,
-  ]
-
-  tailscale_advertise_connector = true
-  # tailscale_advertise_aws_service_names = [
-  #   "GLOBALACCELERATOR",
-  # ]
 
   depends_on = [
     module.vpc.natgw_ids, # ensure NAT gateway is available before instance provisioning - primarily for private subnets

--- a/terraform/aws/aws-ec2-instance-dual-stack-ipv4-ipv6/main.tf
+++ b/terraform/aws/aws-ec2-instance-dual-stack-ipv4-ipv6/main.tf
@@ -51,12 +51,12 @@ module "tailscale_aws_ec2" {
   tailscale_set_preferences = [
     "--auto-update",
     "--ssh",
+    "--advertise-connector",
+    "--advertise-exit-node",
     "--advertise-routes=${join(",", [
       module.vpc.vpc_cidr_block,
       module.vpc.vpc_ipv6_cidr_block,
     ])}",
-    "--advertise-exit-node=true",
-    "--advertise-connector=true",
   ]
 
   depends_on = [

--- a/terraform/aws/aws-ec2-instance-dual-stack-ipv4-ipv6/main.tf
+++ b/terraform/aws/aws-ec2-instance-dual-stack-ipv4-ipv6/main.tf
@@ -50,16 +50,14 @@ module "tailscale_aws_ec2" {
   tailscale_auth_key = tailscale_tailnet_key.main.key
   tailscale_set_preferences = [
     "--auto-update",
+    "--ssh",
+    "--advertise-routes=${join(",", [
+      module.vpc.vpc_cidr_block,
+      module.vpc.vpc_ipv6_cidr_block,
+    ])}",
+    "--advertise-exit-node=true",
+    "--advertise-connector=true",
   ]
-  tailscale_ssh                 = true
-  tailscale_advertise_exit_node = true
-
-  tailscale_advertise_routes = concat(
-    [module.vpc.vpc_cidr_block],
-    [module.vpc.vpc_ipv6_cidr_block],
-  )
-
-  tailscale_advertise_connector = true
 
   depends_on = [
     module.vpc.natgw_ids, # ensure NAT gateway is available before instance provisioning - primarily for private subnets

--- a/terraform/aws/aws-ec2-instance/main.tf
+++ b/terraform/aws/aws-ec2-instance/main.tf
@@ -47,18 +47,11 @@ module "tailscale_aws_ec2" {
   tailscale_auth_key = tailscale_tailnet_key.main.key
   tailscale_set_preferences = [
     "--auto-update",
+    "--ssh",
+    "--advertise-connector",
+    "--advertise-exit-node",
+    "--advertise-routes=${join(",", [module.vpc.vpc_cidr_block])}",
   ]
-  tailscale_ssh                 = true
-  tailscale_advertise_exit_node = true
-
-  tailscale_advertise_routes = [
-    module.vpc.vpc_cidr_block,
-  ]
-
-  tailscale_advertise_connector = true
-  # tailscale_advertise_aws_service_names = [
-  #   "GLOBALACCELERATOR",
-  # ]
 
   depends_on = [
     module.vpc.natgw_ids, # ensure NAT gateway is available before instance provisioning - primarily for private subnets

--- a/terraform/aws/internal-modules/aws-ec2-autoscaling/main.tf
+++ b/terraform/aws/internal-modules/aws-ec2-autoscaling/main.tf
@@ -1,15 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_advertise_connector = var.tailscale_advertise_connector
-  tailscale_advertise_exit_node = var.tailscale_advertise_exit_node
-  tailscale_auth_key            = var.tailscale_auth_key
-  tailscale_hostname            = var.tailscale_hostname
-  tailscale_set_preferences     = var.tailscale_set_preferences
-  tailscale_ssh                 = var.tailscale_ssh
-
-  tailscale_advertise_routes            = var.tailscale_advertise_routes
-  tailscale_advertise_aws_service_names = var.tailscale_advertise_aws_service_names
+  tailscale_auth_key        = var.tailscale_auth_key
+  tailscale_hostname        = var.tailscale_hostname
+  tailscale_set_preferences = var.tailscale_set_preferences
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/aws/internal-modules/aws-ec2-autoscaling/variables-tailscale-install-scripts.tf
+++ b/terraform/aws/internal-modules/aws-ec2-autoscaling/variables-tailscale-install-scripts.tf
@@ -9,21 +9,6 @@ variable "tailscale_hostname" {
   description = "Hostname to assign to the device"
   type        = string
 }
-variable "tailscale_ssh" {
-  description = "Boolean flag to enable Tailscale SSH"
-  type        = bool
-  default     = true
-}
-variable "tailscale_advertise_exit_node" {
-  description = "Boolean flag to enable Tailscale Exit Node"
-  type        = bool
-  default     = false
-}
-variable "tailscale_advertise_connector" {
-  description = "Boolean flag to enable Tailscale App Connector"
-  type        = bool
-  default     = false
-}
 variable "tailscale_set_preferences" {
   description = "Preferences to run via `tailscale set ...`. Do not include `tailscale set`."
   type        = set(string)
@@ -41,19 +26,5 @@ variable "additional_before_scripts" {
 variable "additional_after_scripts" {
   description = "Additional scripts to run AFTER Tailscale scripts"
   type        = list(string)
-  default     = []
-}
-
-#
-# Variables for tailscale-advertise-routes
-#
-variable "tailscale_advertise_routes" {
-  description = "List of routes to advertise"
-  type        = set(string)
-  default     = []
-}
-variable "tailscale_advertise_aws_service_names" {
-  description = "List of AWS Services to retrieve IP prefixes for - e.g. ['GLOBALACCELERATOR','AMAZON']"
-  type        = set(string)
   default     = []
 }

--- a/terraform/aws/internal-modules/aws-ec2-instance/main.tf
+++ b/terraform/aws/internal-modules/aws-ec2-instance/main.tf
@@ -1,9 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_auth_key            = var.tailscale_auth_key
-  tailscale_hostname            = var.tailscale_hostname
-  tailscale_set_preferences     = var.tailscale_set_preferences
+  tailscale_auth_key        = var.tailscale_auth_key
+  tailscale_hostname        = var.tailscale_hostname
+  tailscale_set_preferences = var.tailscale_set_preferences
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/aws/internal-modules/aws-ec2-instance/main.tf
+++ b/terraform/aws/internal-modules/aws-ec2-instance/main.tf
@@ -1,15 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_advertise_connector = var.tailscale_advertise_connector
-  tailscale_advertise_exit_node = var.tailscale_advertise_exit_node
   tailscale_auth_key            = var.tailscale_auth_key
   tailscale_hostname            = var.tailscale_hostname
   tailscale_set_preferences     = var.tailscale_set_preferences
-  tailscale_ssh                 = var.tailscale_ssh
-
-  tailscale_advertise_routes            = var.tailscale_advertise_routes
-  tailscale_advertise_aws_service_names = var.tailscale_advertise_aws_service_names
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/aws/internal-modules/aws-ec2-instance/variables-tailscale-install-scripts.tf
+++ b/terraform/aws/internal-modules/aws-ec2-instance/variables-tailscale-install-scripts.tf
@@ -9,21 +9,6 @@ variable "tailscale_hostname" {
   description = "Hostname to assign to the device"
   type        = string
 }
-variable "tailscale_ssh" {
-  description = "Boolean flag to enable Tailscale SSH"
-  type        = bool
-  default     = true
-}
-variable "tailscale_advertise_exit_node" {
-  description = "Boolean flag to enable Tailscale Exit Node"
-  type        = bool
-  default     = false
-}
-variable "tailscale_advertise_connector" {
-  description = "Boolean flag to enable Tailscale App Connector"
-  type        = bool
-  default     = false
-}
 variable "tailscale_set_preferences" {
   description = "Preferences to run via `tailscale set ...`. Do not include `tailscale set`."
   type        = set(string)
@@ -41,19 +26,5 @@ variable "additional_before_scripts" {
 variable "additional_after_scripts" {
   description = "Additional scripts to run AFTER Tailscale scripts"
   type        = list(string)
-  default     = []
-}
-
-#
-# Variables for tailscale-advertise-routes
-#
-variable "tailscale_advertise_routes" {
-  description = "List of routes to advertise"
-  type        = set(string)
-  default     = []
-}
-variable "tailscale_advertise_aws_service_names" {
-  description = "List of AWS Services to retrieve IP prefixes for - e.g. ['GLOBALACCELERATOR','AMAZON']"
-  type        = set(string)
   default     = []
 }

--- a/terraform/azure/azure-linux-vm/main.tf
+++ b/terraform/azure/azure-linux-vm/main.tf
@@ -67,9 +67,9 @@ module "tailscale_azure_linux_virtual_machine" {
   tailscale_set_preferences = [
     "--auto-update",
     "--ssh",
+    "--advertise-connector",
+    "--advertise-exit-node",
     "--advertise-routes=${join(",", module.network.vnet_address_space)}",
-    "--advertise-exit-node=true",
-    "--advertise-connector=true",
   ]
 
   depends_on = [

--- a/terraform/azure/azure-linux-vm/main.tf
+++ b/terraform/azure/azure-linux-vm/main.tf
@@ -66,13 +66,11 @@ module "tailscale_azure_linux_virtual_machine" {
   tailscale_auth_key = tailscale_tailnet_key.main.key
   tailscale_set_preferences = [
     "--auto-update",
+    "--ssh",
+    "--advertise-routes=${join(",", module.network.vnet_address_space)}",
+    "--advertise-exit-node=true",
+    "--advertise-connector=true",
   ]
-  tailscale_ssh                 = true
-  tailscale_advertise_exit_node = true
-
-  tailscale_advertise_routes = module.network.vnet_address_space
-
-  tailscale_advertise_connector = true
 
   depends_on = [
     module.network.natgw_ids, # for private subnets - ensure NAT gateway is available before instance provisioning

--- a/terraform/azure/internal-modules/azure-linux-vm/main.tf
+++ b/terraform/azure/internal-modules/azure-linux-vm/main.tf
@@ -1,9 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_auth_key            = var.tailscale_auth_key
-  tailscale_hostname            = var.tailscale_hostname
-  tailscale_set_preferences     = var.tailscale_set_preferences
+  tailscale_auth_key        = var.tailscale_auth_key
+  tailscale_hostname        = var.tailscale_hostname
+  tailscale_set_preferences = var.tailscale_set_preferences
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/azure/internal-modules/azure-linux-vm/main.tf
+++ b/terraform/azure/internal-modules/azure-linux-vm/main.tf
@@ -1,15 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_advertise_connector = var.tailscale_advertise_connector
-  tailscale_advertise_exit_node = var.tailscale_advertise_exit_node
   tailscale_auth_key            = var.tailscale_auth_key
   tailscale_hostname            = var.tailscale_hostname
   tailscale_set_preferences     = var.tailscale_set_preferences
-  tailscale_ssh                 = var.tailscale_ssh
-
-  tailscale_advertise_routes            = var.tailscale_advertise_routes
-  tailscale_advertise_aws_service_names = var.tailscale_advertise_aws_service_names
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/azure/internal-modules/azure-linux-vm/variables-tailscale-install-scripts.tf
+++ b/terraform/azure/internal-modules/azure-linux-vm/variables-tailscale-install-scripts.tf
@@ -9,21 +9,6 @@ variable "tailscale_hostname" {
   description = "Hostname to assign to the device"
   type        = string
 }
-variable "tailscale_ssh" {
-  description = "Boolean flag to enable Tailscale SSH"
-  type        = bool
-  default     = true
-}
-variable "tailscale_advertise_exit_node" {
-  description = "Boolean flag to enable Tailscale Exit Node"
-  type        = bool
-  default     = false
-}
-variable "tailscale_advertise_connector" {
-  description = "Boolean flag to enable Tailscale App Connector"
-  type        = bool
-  default     = false
-}
 variable "tailscale_set_preferences" {
   description = "Preferences to run via `tailscale set ...`. Do not include `tailscale set`."
   type        = set(string)
@@ -41,19 +26,5 @@ variable "additional_before_scripts" {
 variable "additional_after_scripts" {
   description = "Additional scripts to run AFTER Tailscale scripts"
   type        = list(string)
-  default     = []
-}
-
-#
-# Variables for tailscale-advertise-routes
-#
-variable "tailscale_advertise_routes" {
-  description = "List of routes to advertise"
-  type        = set(string)
-  default     = []
-}
-variable "tailscale_advertise_aws_service_names" {
-  description = "List of AWS Services to retrieve IP prefixes for - e.g. ['GLOBALACCELERATOR','AMAZON']"
-  type        = set(string)
   default     = []
 }

--- a/terraform/google/google-compute-instance/main.tf
+++ b/terraform/google/google-compute-instance/main.tf
@@ -59,13 +59,11 @@ module "tailscale_instance" {
   tailscale_auth_key = tailscale_tailnet_key.main.key
   tailscale_set_preferences = [
     "--auto-update",
+    "--ssh",
+    "--advertise-routes=${join(",", module.vpc.subnets_ips)}",
+    "--advertise-exit-node=true",
+    "--advertise-connector=true",
   ]
-  tailscale_ssh                 = true
-  tailscale_advertise_exit_node = true
-
-  tailscale_advertise_routes = module.vpc.subnets_ips
-
-  tailscale_advertise_connector = true
 
   depends_on = [
     module.vpc.nat_ids, # ensure NAT gateway is available before instance provisioning - primarily for private subnets

--- a/terraform/google/google-compute-instance/main.tf
+++ b/terraform/google/google-compute-instance/main.tf
@@ -60,9 +60,9 @@ module "tailscale_instance" {
   tailscale_set_preferences = [
     "--auto-update",
     "--ssh",
+    "--advertise-connector",
+    "--advertise-exit-node",
     "--advertise-routes=${join(",", module.vpc.subnets_ips)}",
-    "--advertise-exit-node=true",
-    "--advertise-connector=true",
   ]
 
   depends_on = [

--- a/terraform/google/internal-modules/google-compute-instance/main.tf
+++ b/terraform/google/internal-modules/google-compute-instance/main.tf
@@ -1,9 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_auth_key            = var.tailscale_auth_key
-  tailscale_hostname            = var.tailscale_hostname
-  tailscale_set_preferences     = var.tailscale_set_preferences
+  tailscale_auth_key        = var.tailscale_auth_key
+  tailscale_hostname        = var.tailscale_hostname
+  tailscale_set_preferences = var.tailscale_set_preferences
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/google/internal-modules/google-compute-instance/main.tf
+++ b/terraform/google/internal-modules/google-compute-instance/main.tf
@@ -1,15 +1,9 @@
 module "tailscale_install_scripts" {
   source = "../../../internal-modules/tailscale-install-scripts"
 
-  tailscale_advertise_connector = var.tailscale_advertise_connector
-  tailscale_advertise_exit_node = var.tailscale_advertise_exit_node
   tailscale_auth_key            = var.tailscale_auth_key
   tailscale_hostname            = var.tailscale_hostname
   tailscale_set_preferences     = var.tailscale_set_preferences
-  tailscale_ssh                 = var.tailscale_ssh
-
-  tailscale_advertise_routes            = var.tailscale_advertise_routes
-  tailscale_advertise_aws_service_names = var.tailscale_advertise_aws_service_names
 
   additional_before_scripts = var.additional_before_scripts
   additional_after_scripts  = var.additional_after_scripts

--- a/terraform/google/internal-modules/google-compute-instance/variables-tailscale-install-scripts.tf
+++ b/terraform/google/internal-modules/google-compute-instance/variables-tailscale-install-scripts.tf
@@ -9,21 +9,6 @@ variable "tailscale_hostname" {
   description = "Hostname to assign to the device"
   type        = string
 }
-variable "tailscale_ssh" {
-  description = "Boolean flag to enable Tailscale SSH"
-  type        = bool
-  default     = true
-}
-variable "tailscale_advertise_exit_node" {
-  description = "Boolean flag to enable Tailscale Exit Node"
-  type        = bool
-  default     = false
-}
-variable "tailscale_advertise_connector" {
-  description = "Boolean flag to enable Tailscale App Connector"
-  type        = bool
-  default     = false
-}
 variable "tailscale_set_preferences" {
   description = "Preferences to run via `tailscale set ...`. Do not include `tailscale set`."
   type        = set(string)
@@ -41,19 +26,5 @@ variable "additional_before_scripts" {
 variable "additional_after_scripts" {
   description = "Additional scripts to run AFTER Tailscale scripts"
   type        = list(string)
-  default     = []
-}
-
-#
-# Variables for tailscale-advertise-routes
-#
-variable "tailscale_advertise_routes" {
-  description = "List of routes to advertise"
-  type        = set(string)
-  default     = []
-}
-variable "tailscale_advertise_aws_service_names" {
-  description = "List of AWS Services to retrieve IP prefixes for - e.g. ['GLOBALACCELERATOR','AMAZON']"
-  type        = set(string)
   default     = []
 }

--- a/terraform/internal-modules/tailscale-advertise-routes/README.md
+++ b/terraform/internal-modules/tailscale-advertise-routes/README.md
@@ -1,3 +1,24 @@
 # saas-route-lists
 
 Scripts to download, parse, and save various SaaS IP and domain lists to advertise via a Tailscale App Connector or Subnet Router.
+
+## Usage
+
+```hcl
+module "tailscale-advertise-routes" {
+  source = "../../internal-modules/tailscale-advertise-routes"
+
+  tailscale_advertise_aws_service_names = ["GLOBALACCELERATOR"]
+  tailscale_advertise_routes            = [module.vpc.vpc_cidr_block] # ensure initial routes list is re-added
+}
+
+module "tailscale_aws_ec2_autoscaling" {
+  source = "../internal-modules/aws-ec2-autoscaling/"
+
+  // other inputs omitted
+
+  additional_after_scripts = [
+    module.tailscale-advertise-routes.routes_script,
+  ]
+}
+```

--- a/terraform/internal-modules/tailscale-advertise-routes/variables.tf
+++ b/terraform/internal-modules/tailscale-advertise-routes/variables.tf
@@ -5,6 +5,7 @@
 variable "tailscale_advertise_routes_from_file_on_host" {
   description = "File on the host to append (sorted and distinct) routes to"
   type        = string
+  default     = "/root/tailscale-routes-to-advertise.txt"
 }
 variable "tailscale_advertise_routes" {
   description = "List of subnets to advertise"

--- a/terraform/internal-modules/tailscale-install-scripts/variables.tf
+++ b/terraform/internal-modules/tailscale-install-scripts/variables.tf
@@ -9,21 +9,6 @@ variable "tailscale_hostname" {
   description = "Hostname to assign to the device"
   type        = string
 }
-variable "tailscale_ssh" {
-  description = "Boolean flag to enable Tailscale SSH"
-  type        = bool
-  default     = true
-}
-variable "tailscale_advertise_exit_node" {
-  description = "Boolean flag to enable Tailscale Exit Node"
-  type        = bool
-  default     = false
-}
-variable "tailscale_advertise_connector" {
-  description = "Boolean flag to enable Tailscale App Connector"
-  type        = bool
-  default     = false
-}
 variable "tailscale_set_preferences" {
   description = "Preferences to run via `tailscale set ...`. Do not include `tailscale set`."
   type        = set(string)
@@ -41,19 +26,5 @@ variable "additional_before_scripts" {
 variable "additional_after_scripts" {
   description = "Additional scripts to run AFTER Tailscale scripts"
   type        = list(string)
-  default     = []
-}
-
-#
-# Variables for tailscale-advertise-routes
-#
-variable "tailscale_advertise_routes" {
-  description = "List of routes to advertise"
-  type        = set(string)
-  default     = []
-}
-variable "tailscale_advertise_aws_service_names" {
-  description = "List of AWS Services to retrieve IP prefixes for - e.g. ['GLOBALACCELERATOR','AMAZON']"
-  type        = set(string)
   default     = []
 }


### PR DESCRIPTION
Use `tailscale_set_preferences` for most module inputs instead of `tailscale_ssh`, etc.