### PR TITLE
terraform: remove source dest check instance property

### DIFF
--- a/terraform/aws/aws-ec2-autoscaling-dual-subnet/main.tf
+++ b/terraform/aws/aws-ec2-autoscaling-dual-subnet/main.tf
@@ -68,8 +68,6 @@ resource "aws_network_interface" "secondary" {
   subnet_id       = local.private_subnet_id
   security_groups = local.security_group_ids
   tags            = merge(local.aws_tags, { Name = "${local.name}-secondary" })
-
-  source_dest_check = false
 }
 
 module "tailscale_aws_ec2_autoscaling" {

--- a/terraform/aws/internal-modules/aws-ec2-instance/main.tf
+++ b/terraform/aws/internal-modules/aws-ec2-instance/main.tf
@@ -37,7 +37,6 @@ resource "aws_instance" "tailscale_instance" {
   subnet_id              = var.subnet_id
   vpc_security_group_ids = var.vpc_security_group_ids
   ipv6_address_count     = var.ipv6_address_count
-  source_dest_check      = !module.tailscale_install_scripts.ip_forwarding_required
 
   iam_instance_profile = var.instance_profile_name
 

--- a/terraform/azure/internal-modules/azure-linux-vm/main.tf
+++ b/terraform/azure/internal-modules/azure-linux-vm/main.tf
@@ -23,7 +23,6 @@ resource "azurerm_network_interface" "primary" {
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = var.public_ip_address_id
   }
-  ip_forwarding_enabled = module.tailscale_install_scripts.ip_forwarding_required
 }
 
 resource "azurerm_network_interface_security_group_association" "tailscale" {

--- a/terraform/google/internal-modules/google-compute-instance/main.tf
+++ b/terraform/google/internal-modules/google-compute-instance/main.tf
@@ -40,5 +40,4 @@ resource "google_compute_instance" "tailscale_instance" {
   tags     = var.instance_tags
 
   metadata_startup_script = module.tailscale_install_scripts.ubuntu_install_script
-  can_ip_forward          = module.tailscale_install_scripts.ip_forwarding_required
 }

--- a/terraform/internal-modules/tailscale-install-scripts/main.tf
+++ b/terraform/internal-modules/tailscale-install-scripts/main.tf
@@ -32,8 +32,8 @@ locals {
     "--hostname=${var.tailscale_hostname}",
   ]
 
-  ip_forwarding_required = length([for x in ["--advertise-exit-node", "--advertise-connector", "--advertise-routes"] : x if strcontains(x, "advertisfe")]) > 0
-  ip_forwarding_script   = local.ip_forwarding_required ? "" : templatefile("${path.module}/scripts/additional-scripts/ip-forwarding.tftpl", {})
+  ip_forwarding_required = length([for x in var.tailscale_set_preferences : x if strcontains(x, "advertise")]) > 0
+  ip_forwarding_script   = local.ip_forwarding_required == false ? "" : templatefile("${path.module}/scripts/additional-scripts/ip-forwarding.tftpl", {})
 
   ethtool_udp_optimization_script = templatefile("${path.module}/scripts/additional-scripts/ethtool-udp.tftpl", {})
 }

--- a/terraform/internal-modules/tailscale-install-scripts/outputs.tf
+++ b/terraform/internal-modules/tailscale-install-scripts/outputs.tf
@@ -6,10 +6,6 @@ output "ubuntu_install_script_base64_encoded" {
   value = base64encode(local.ubuntu_install_script)
 }
 
-output "ip_forwarding_required" {
-  value = local.ip_forwarding_required
-}
-
 output "ubuntu_install_script_md5" {
   description = "MD5 hash of the VM user_data script - for detecting changes"
   value       = md5(local.ubuntu_install_script)


### PR DESCRIPTION
Disabling source/destination checks (https://docs.aws.amazon.com/vpc/latest/userguide/work-with-nat-instances.html#EIP_Disable_SrcDestCheck) is only required when `--snat-subnet-routes=false`. Remove the property from the examples to eliminate confusion.