### PR TITLE
devcontainer: remove runArgs - no longer needed

### DIFF
--- a/.devcontainer/with-tailscale/devcontainer.json
+++ b/.devcontainer/with-tailscale/devcontainer.json
@@ -1,6 +1,5 @@
 {
   "name": "Codespace with Tailscale",
-  "runArgs": ["--device=/dev/net/tun"],
   "features": {
     "ghcr.io/tailscale/codespace/tailscale": {}
   }


### PR DESCRIPTION
runArgs no longer needed per https://github.com/tailscale/codespace/commit/1a205b972686bdac2cf133042ba16958cbcaad87